### PR TITLE
Correct length of otherReasonInfo

### DIFF
--- a/specs/UASZone.json
+++ b/specs/UASZone.json
@@ -61,7 +61,7 @@
     },
     "otherReasonInfo": {
       "type": "string",
-      "maxLength": 30
+      "maxLength": 200
     },
     "regulationExemption": {
       "type": "string",


### PR DESCRIPTION
corrected the maximum length of the otherReasonInfo (according to the maximum length of the TextShortType data type)