### PR TITLE
UASZonesFileWithMetadata.json: Set properties as required field.

### DIFF
--- a/specs/UASZonesFileWithMetadata.json
+++ b/specs/UASZonesFileWithMetadata.json
@@ -16,5 +16,8 @@
             "items": {"$ref": "UASZone.json"},
             "minItems": 1
         }
-    }
+    },
+    "required": [
+        "properties"
+    ]
 }


### PR DESCRIPTION
`features` has a `minItems` field but `properties` itself doesn't so without this change a file with just `{}` could be considered as matching this schema.